### PR TITLE
Use new seq.TRID() function to assign TRID labels

### DIFF
--- a/pge2/2DGRE/main.m
+++ b/pge2/2DGRE/main.m
@@ -45,7 +45,7 @@ if createSequenceFile
     % Plot the psq sequence
     %---------------------------------------------------------------
     S = pge2.plot(psq, sys_ge, 'blockRange', [1 2], 'rotate', false, 'interpolate', false);
-    S = pge2.plot(psq, sys_ge, 'timeRange',  [0 0.02], 'rotate', true);
+    %S = pge2.plot(psq, sys_ge, 'timeRange',  [0 0.02], 'rotate', true);
 
     %---------------------------------------------------------------
     % Validate psq representation against the original .seq file
@@ -57,10 +57,10 @@ if createSequenceFile
     pge2.validate(psq, sys_ge, seq, [], 'row', [], 'plot', false);
 
     % Plot each segment instance before proceeding
-    pge2.validate(psq, sys_ge, seq, [], 'row', [], 'plot', true);
+    %pge2.validate(psq, sys_ge, seq, [], 'row', [], 'plot', true);
 
     % Check only segments beginning at/after block 1000
-    pge2.validate(psq, sys_ge, seq, [], 'row', 1000, 'plot', true);
+    %pge2.validate(psq, sys_ge, seq, [], 'row', 1000, 'plot', true);
 
     %---------------------------------------------------------------
     % Apply slice offset and write PulSeg object to .pge file.
@@ -69,7 +69,7 @@ if createSequenceFile
     %---------------------------------------------------------------
     xloc = 0;
     yloc = 0;
-    zloc = 3.2e-2;   % m
+    zloc = 0;   % m
     psq = pge2.translateFOVrf(psq, [xloc yloc zloc]);
     pge2.serialize(psq, [fn '.pge'], 'pislquant', 10, 'params', params, 'checkHash', false);
 
@@ -77,9 +77,8 @@ if createSequenceFile
     % Validate the GE simulator XML output (created by WTools/Pulse View)
     % against the original .seq file.  For MR30.2 and later.
     %---------------------------------------------------------------
-    xml_path = '~/transfer/xml/';   % directory for Pulse View .xml files
-
-    pge2.validate(psq, sys_ge, seq, xml_path, 'row', [], 'plot', true);
+    %xml_path = '~/transfer/xml/';   % directory for Pulse View .xml files
+    %pge2.validate(psq, sys_ge, seq, xml_path, 'row', [], 'plot', true);
 
     % Coming soon: Check mechanical resonances (forbidden frequency bands)
 end

--- a/pge2/2DGRE/setup.m
+++ b/pge2/2DGRE/setup.m
@@ -1,5 +1,5 @@
 % get Pulseq toolbox
-system('git clone --branch v1.5.1 git@github.com:pulseq/pulseq.git');
+system('git clone --branch master git@github.com:pulseq/pulseq.git');
 addpath pulseq/matlab
 
 % get toolbox to convert .seq file to a PulSeg sequence (psq) object

--- a/pge2/2DGRE/write2DGRE.m
+++ b/pge2/2DGRE/write2DGRE.m
@@ -111,11 +111,9 @@ for iY = (-n_dummy_shots-pislquant+1):n_y
     rf_increment = mod(rf_increment+rf_spoiling_increment, 360.0);
     rf_phase = mod(rf_phase+rf_increment, 360.0);
 
-    % Mark start of segment instance (block group) by adding TRID label.
-    % The TRID can be any postivie integer, but must be unique to each segment.
+    % Mark start of each segment instance (block group) by adding TRID label.
     % Subsequent blocks in block group are NOT labelled (this is akin to 
     % the use of SEQLENGTH in EPIC to define segments/cores).
-    % The TRID label can belong to a block with zero or more other events.
     %
     % Note the distinction here between 'segment' and 'segment instance':
     %
@@ -135,16 +133,23 @@ for iY = (-n_dummy_shots-pislquant+1):n_y
     %          - RF frequency offset
     %          - RF/ADC phase offsets
     %          - duration of pure delay blocks (see below)
-    seq.addBlock(mr.makeLabel('SET', 'TRID', 1 + is_dummy_tr + 2*is_receive_gain_calibration_tr));
-    seq.addBlock(rf, gz);   % excitation block
+    if is_dummy_tr
+        seq.addTRID('dummy');
+    elseif is_receive_gain_calibration_tr
+        seq.addTRID('receive_gain');
+    else
+        seq.addTRID('acquire');
+    end
     % Alternative:
-    % seq.addBlock(rf, gz, mr.makeLabel('SET', 'TRID', 1 + is_dummy_tr + 2*is_receive_gain_calibration_tr));
+    %seq.addBlock(mr.makeLabel('SET', 'TRID', 1 + is_dummy_tr + 2*is_receive_gain_calibration_tr));
+
+    % excitation block
+    seq.addBlock(rf, gz);
 
     % Slice-select refocus and readout prephasing block
     % Set phase-encode gradients to ~zero while iY < 1
     pesc = (iY>0) * pe_scales(max(iY,1));  % phase-encode gradient scaling
     pesc = pesc + (pesc == 0)*eps;        % non-zero scaling so that the trapezoid shape is preserved in the .seq file
-
     seq.addBlock(gx_pre, mr.scaleGrad(gy_pre, pesc), gz_reph);
 
     % Empty blocks with a label is ok -- for now they are ignored by the GE interpreter.
@@ -186,7 +191,7 @@ n_noise_scans = 5;
 for s = 1:n_noise_scans
     % Now we need to define a different sub-sequence,
     % so we need to label start of segment instance with a new unique TRID
-    seq.addBlock(mr.makeLabel('SET', 'TRID', 48));  % any unique positive int
+    seq.addTRID('noise_scan');  % any unique positive int
     seq.addBlock(mr.makeDelay(1)); 
     seq.addBlock(adc);
     seq.addBlock(mr.makeDelay(500e-6)); % make room for psd_grd_wait (gradient/ADC delay) and ADC ringdown


### PR DESCRIPTION
Use new seq.TRID() function to assign TRID labels, instead of manually assigned integer numbers.